### PR TITLE
fix error when running training code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "deepspeed==0.15.4",
     "moshi==0.1.0",
     "soundfile>=0.12.1",
+    "sphn==0.1.12",
     "torch>=2.4.1",
     "torchaudio>=2.4.1",
     "transformers>=4.46.1",

--- a/tools/zero_to_fp32.py
+++ b/tools/zero_to_fp32.py
@@ -21,9 +21,9 @@ import json
 import math
 import os
 import re
-import typing
 from collections import OrderedDict
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import torch
 from deepspeed.checkpoint.constants import (
@@ -630,7 +630,11 @@ def convert_zero_checkpoint_to_fp32_state_dict(
             state_dict, filename_pattern=filename_pattern, max_shard_size=max_shard_size
         )
     else:
-        StateDictSplit = typing.NamedTuple("StateDictSplit", ["is_sharded", "filename_to_tensors"])
+
+        class StateDictSplit(NamedTuple):
+            is_sharded: bool
+            filename_to_tensors: dict
+
         state_dict_split = StateDictSplit(
             is_sharded=False, filename_to_tensors={weights_name: list(state_dict.keys())}
         )


### PR DESCRIPTION
Fix error when running training code

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/groups/gcg51557/experiments/0215_audio_llm/moshi-finetune/tools/zero_to_fp32.py", line 750, in <module>
    convert_zero_checkpoint_to_fp32_state_dict(
  File "/groups/gcg51557/experiments/0215_audio_llm/moshi-finetune/tools/zero_to_fp32.py", line 633, in convert_zero_checkpoint_to_fp32_state_dict
    StateDictSplit = typing.NamedTuple("StateDictSplit", ["is_sharded", "filename_to_tensors"])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ach18062do/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/typing.py", line 2874, in NamedTuple
    nt = _make_nmtuple(typename, fields, module=_caller())
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ach18062do/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/typing.py", line 2796, in _make_nmtuple
    fields = [n for n, t in types]
                    ^^^^
ValueError: too many values to unpack (expected 2)
```